### PR TITLE
Fix: Rewards panel expanding indefinitely

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1222,7 +1222,9 @@ function handleRequestFinished(request) {
                 rewards.source = msg.responseData.context;
                 console.debug(rewards);
                 if (showOptions.showRewards) {
-                  showRewards(rewards);
+                  rewards.forEach((reward) => {
+                    showReward(reward);
+                  })
                 }
               }
             } else if (msg.requestMethod == '') {


### PR DESCRIPTION
Rewards panel should no longer expand indefinitely and should save the size set by the user.