### PR TITLE
Fix constants export syntax

### DIFF
--- a/src/js/fn/constants.js
+++ b/src/js/fn/constants.js
@@ -1,2 +1,3 @@
+const salt = 'notquitesafewaytostoreinfo';
 
-export salt = 'notquitesafewaytostoreinfo';
+export { salt };


### PR DESCRIPTION
## Summary
- fix `salt` export syntax in fn/constants.js

## Testing
- `npm run check`
- `npm run build-foe-info`

------
https://chatgpt.com/codex/tasks/task_e_68435d470340832189921f3241f70fd6