### PR TITLE
Fix French translation for diamonds

### DIFF
--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -6,7 +6,7 @@
     "message-documentation": "qqq"
   },
   "bonus": "Bonus",
-  "diamonds": "Diamands",
+  "diamonds": "Diamants",
   "please": "SVP mettre à jour",
   "load": "Actualiser pour voir les statistiques de votre ville",
   "available": "PF disponible",


### PR DESCRIPTION
## Summary
- fix the French translation for "diamonds" in `fr.json`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68436ee752d08321b71f92d3bb11ec69