### PR TITLE
Fix metadata handling and forge point boosts

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -141,6 +141,10 @@ export var VolcanoProvinceDefs = [];
 export var WaterfallProvinceDefs = [];
 export var BuildingDefs = [];
 export var hiddenRewards = [];
+// flag to indicate that all metadata files have been processed
+var metadataLoaded = false;
+// store StartupService message until metadata is ready
+var pendingStartupMsg = null;
 export var Goods = {
   sash: 0,
   sat: 0,
@@ -725,6 +729,11 @@ function handleRequestFinished(request) {
               }
             }
             storage.set('CityEntityDefs', CityEntityDefs);
+            metadataLoaded = true;
+            if (pendingStartupMsg) {
+              startupService(pendingStartupMsg);
+              pendingStartupMsg = null;
+            }
           } else if (
             msg.requestClass == 'CampaignService' &&
             msg.requestMethod == 'getDeposits'
@@ -1026,7 +1035,11 @@ function handleRequestFinished(request) {
             visitstats.className = '';
             cultural.innerHTML = ``;
             cultural.className = '';
-            startupService(msg);
+            if (metadataLoaded) {
+              startupService(msg);
+            } else {
+              pendingStartupMsg = msg;
+            }
 
             /*Player Info */
           } else if (

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -715,47 +715,16 @@ function handleRequestFinished(request) {
             msg.requestClass === 'StaticDataService' &&
             msg.requestMethod == 'getMetadata'
           ) {
-            // find an URL that has city entities
-            const cityEntitiesURL = msg.responseData.find(
-              (item) => item.identifier === 'city_entities',
-            ).url;
-            // fetch it via ajax
-            let response = await fetch(cityEntitiesURL);
-            // parse response to JSON
-            const cityEntitiesJSON = await response.json();
-
-            // run the code that prefills city entities ( copied from somewhere bellow )
-            cityEntitiesJSON.forEach(function (msg) {
-              if (
-                msg.__class__ &&
-                msg.__class__.substring(0, 10) == 'CityEntity'
-              ) {
-                if (!CityEntityDefs[msg.id]) {
-                  CityEntityDefs[msg.id] = {
-                    name: msg.name,
-                    abilities: [],
-                    entity_levels: [],
-                    available_products: [],
-                  };
-                }
-                // console.debug(msg.name,msg);
-                CityEntityDefs[msg.id] = msg;
-              } else if (
-                msg.__class__ &&
-                msg.__class__ == 'GenericCityEntity'
-              ) {
-                if (!CityEntityDefs[msg.id]) {
-                  CityEntityDefs[msg.id] = {
-                    name: msg.name,
-                    abilities: [],
-                    entity_levels: [],
-                    available_products: [],
-                  };
-                }
-                // console.debug(msg.name,msg);
-                CityEntityDefs[msg.id] = msg;
+            for (const item of msg.responseData) {
+              try {
+                const resp = await fetch(item.url);
+                const data = await resp.json();
+                data.forEach(processMetadataEntry);
+              } catch (e) {
+                console.error('metadata fetch failed', item, e);
               }
-            });
+            }
+            storage.set('CityEntityDefs', CityEntityDefs);
           } else if (
             msg.requestClass == 'CampaignService' &&
             msg.requestMethod == 'getDeposits'
@@ -1983,95 +1952,10 @@ function handleRequestFinished(request) {
               /**/
             } else console.debug('AutoAidService', msg);
           } else {
-            //output.innerHTML += `<div>*** ${msg.requestClass}</div>`;
+            // output.innerHTML += `<div>*** ${msg.requestClass}</div>`;
             if (msg.requestClass == null) {
-              if (msg.id == 'W_MultiAge_WIN22A11b') {
-                console.info(msg.name, msg);
-              }
-              if (
-                msg.__class__ &&
-                (msg.__class__ == 'CityEntityCulturalGoodsBuilding' ||
-                  msg.__class__ == 'CityEntityImpediment' ||
-                  msg.__class__ == 'CityEntityDiplomacy' ||
-                  msg.__class__ == 'CityEntityStaticProvider' ||
-                  msg.__class__ == 'CityEntityStreet' ||
-                  msg.__class__ == 'CityEntityHub' ||
-                  msg.__class__ == 'CityEntityOutpostShip' ||
-                  msg.__class__ == 'QuestTabMetadata' ||
-                  msg.__class__ == 'ChainMetadata' ||
-                  msg.__class__ == 'BuildingSetMetadata' ||
-                  msg.__class__ == 'InfoScreen' ||
-                  msg.type == 'off_grid')
-              ) {
-                // ignore these
-                //   console.debug(msg.name, msg);
-              } else if (
-                msg.__class__ &&
-                msg.__class__.substring(0, 10) == 'CityEntity'
-              ) {
-                if (!CityEntityDefs[msg.id]) {
-                  CityEntityDefs[msg.id] = {
-                    name: msg.name,
-                    abilities: [],
-                    entity_levels: [],
-                    available_products: [],
-                  };
-                }
-                // console.debug(msg.name,msg);
-                CityEntityDefs[msg.id] = msg;
-              } else if (
-                msg.__class__ &&
-                msg.__class__ == 'GenericCityEntity'
-              ) {
-                if (!CityEntityDefs[msg.id]) {
-                  CityEntityDefs[msg.id] = {
-                    name: msg.name,
-                    abilities: [],
-                    entity_levels: [],
-                    available_products: [],
-                  };
-                }
-                // console.debug(msg.name,msg);
-                CityEntityDefs[msg.id] = msg;
-              } else if (msg.__class__ && msg.__class__ == 'UnitType') {
-                // MilitaryDefs.push([msg.unitTypeId,msg.name,msg.minEra]);
-                MilitaryDefs[msg.unitTypeId] = {
-                  name: msg.name,
-                  era: msg.minEra,
-                };
-              } else if (
-                msg.__class__ &&
-                msg.__class__ == 'CastleSystemLevelMetadata'
-              ) {
-                CastleDefs.push(msg);
-                //   console.debug(`CastleSystemLevelMetadata`, msg, CastleDefs);
-              } else if (
-                msg.__class__ &&
-                msg.__class__ == 'SelectionKitMetadata'
-              ) {
-                SelectionKitDefs.push(msg);
-                // console.debug(`SelectionKitMetadata`, msg,SelectionKitDefs);
-              } else if (msg.__class__ && msg.__class__ == 'BoostMetadata') {
-                BoostMetadataDefs.push(msg);
-                // console.debug(`BoostMetadata`, msg,BoostMetadataDefs);
-              } else if (
-                msg.__class__ &&
-                msg.__class__.substring(0, 18) == 'CityEntityCultural'
-              ) {
-                // console.debug(`CityEntityCultural`, msg.name,msg);
-              } else if (msg.__class__ && msg.__class__ == 'BuildingUpgrade') {
-                // console.debug(`BuildingUpgrade`, msg.name,msg);
-              } else if (msg.__class__ && msg.__class__ == 'CityMapEntity') {
-                //
-                if (msg.id == 'W_MultiAge_WIN22A11b') {
-                  console.info(msg.name, msg);
-                }
-              } else if (!msg.__class__) {
-                // console.debug(`NO __class__`, msg.name,msg);
-              } else console.debug(msg.name, msg);
+              processMetadataEntry(msg);
             }
-
-            // if(msg.__class__ && msg.__class__.substring(0,10) == 'CityEntity' && msg.type != 'military' && msg.type != 'off_grid'
           }
         }
         // console.debug(parsed);
@@ -2669,6 +2553,72 @@ function rewardObserve() {
   resizeObserver.observe(rewardDiv);
   if ($('#rewardsText').height() > toolOptions.rewardSize) {
     $('#rewardsText').height(toolOptions.rewardSize);
+  }
+}
+
+function processMetadataEntry(msg) {
+  if (
+    msg.__class__ &&
+    (msg.__class__ == 'CityEntityCulturalGoodsBuilding' ||
+      msg.__class__ == 'CityEntityImpediment' ||
+      msg.__class__ == 'CityEntityDiplomacy' ||
+      msg.__class__ == 'CityEntityStaticProvider' ||
+      msg.__class__ == 'CityEntityStreet' ||
+      msg.__class__ == 'CityEntityHub' ||
+      msg.__class__ == 'CityEntityOutpostShip' ||
+      msg.__class__ == 'QuestTabMetadata' ||
+      msg.__class__ == 'ChainMetadata' ||
+      msg.__class__ == 'BuildingSetMetadata' ||
+      msg.__class__ == 'InfoScreen' ||
+      msg.type == 'off_grid')
+  ) {
+    return;
+  } else if (msg.__class__ && msg.__class__.substring(0, 10) == 'CityEntity') {
+    if (!CityEntityDefs[msg.id]) {
+      CityEntityDefs[msg.id] = {
+        name: msg.name,
+        abilities: [],
+        entity_levels: [],
+        available_products: [],
+      };
+    }
+    CityEntityDefs[msg.id] = msg;
+  } else if (msg.__class__ && msg.__class__ == 'GenericCityEntity') {
+    if (!CityEntityDefs[msg.id]) {
+      CityEntityDefs[msg.id] = {
+        name: msg.name,
+        abilities: [],
+        entity_levels: [],
+        available_products: [],
+      };
+    }
+    CityEntityDefs[msg.id] = msg;
+  } else if (msg.__class__ && msg.__class__ == 'UnitType') {
+    MilitaryDefs[msg.unitTypeId] = {
+      name: msg.name,
+      era: msg.minEra,
+    };
+  } else if (msg.__class__ && msg.__class__ == 'CastleSystemLevelMetadata') {
+    CastleDefs.push(msg);
+  } else if (msg.__class__ && msg.__class__ == 'SelectionKitMetadata') {
+    SelectionKitDefs.push(msg);
+  } else if (msg.__class__ && msg.__class__ == 'BoostMetadata') {
+    BoostMetadataDefs.push(msg);
+  } else if (
+    msg.__class__ &&
+    msg.__class__.substring(0, 18) == 'CityEntityCultural'
+  ) {
+    // ignore
+  } else if (msg.__class__ && msg.__class__ == 'BuildingUpgrade') {
+    // ignore
+  } else if (msg.__class__ && msg.__class__ == 'CityMapEntity') {
+    if (msg.id == 'W_MultiAge_WIN22A11b') {
+      console.info(msg.name, msg);
+    }
+  } else if (!msg.__class__) {
+    return;
+  } else {
+    console.debug(msg.name, msg);
   }
 }
 

--- a/src/js/msg/StartupService.js
+++ b/src/js/msg/StartupService.js
@@ -1145,6 +1145,31 @@ export function boostServiceAllBoosts(msg) {
           City.QIDefendingDefense += boost[j].value;
         }
         // console.debug('City Attack/Defense:', boost[j].value);
+      } else if (boost[j].type == 'att_def_boost_attacker_defender') {
+        if (boost[j].targetedFeature == 'all') {
+          City.Attack += boost[j].value;
+          City.Defense += boost[j].value;
+          City.CityAttack += boost[j].value;
+          City.CityDefense += boost[j].value;
+        } else if (boost[j].targetedFeature == 'battleground') {
+          City.GBGAttackingAttack += boost[j].value;
+          City.GBGAttackingDefense += boost[j].value;
+          City.GBGDefendingAttack += boost[j].value;
+          City.GBGDefendingDefense += boost[j].value;
+        } else if (boost[j].targetedFeature == 'guild_expedition') {
+          City.GEAttackingAttack += boost[j].value;
+          City.GEAttackingDefense += boost[j].value;
+          City.GEDefendingAttack += boost[j].value;
+          City.GEDefendingDefense += boost[j].value;
+        } else if (boost[j].targetedFeature == 'guild_raids') {
+          City.QIAttackingAttack += boost[j].value;
+          City.QIAttackingDefense += boost[j].value;
+          City.QIDefendingAttack += boost[j].value;
+          City.QIDefendingDefense += boost[j].value;
+        }
+        // console.debug('Attack/Defense for Att/Def:', boost[j].value);
+      } else if (boost[j].type == 'forge_points_production') {
+        City.ForgePoints += boost[j].value;
       } else if (
         boost[j].type != 'city_shield' &&
         boost[j].type != 'life_support' &&


### PR DESCRIPTION
## Summary
- streamline metadata parsing by calling `processMetadataEntry`
- count `forge_points_production` in boost totals

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68438afd1aa883218b3c832aa01bdb5d