### PR TITLE
Fix unit bonus when not motivated

### DIFF
--- a/src/js/msg/StartupService.js
+++ b/src/js/msg/StartupService.js
@@ -188,7 +188,9 @@ export function startupService(msg) {
             entity.abilities &&
             entity.abilities.find(
               (id) => id.__class__ == 'RandomUnitOfAgeWhenMotivatedAbility',
-            )
+            ) &&
+            mapID.state &&
+            mapID.state.is_motivated
           ) {
             City.TrazUnits += entity.abilities.find(
               (id) => id.__class__ == 'RandomUnitOfAgeWhenMotivatedAbility',


### PR DESCRIPTION
## Summary
- check building motivation state before adding RandomUnitOfAgeWhenMotivatedAbility units

## Testing
- `npm run check`
- `npm run build-foe-info`

------
https://chatgpt.com/codex/tasks/task_e_6843d51e908c83219aeabbfddacba917