### PR TITLE
Handle RandomChestRewardAbility units

### DIFF
--- a/src/js/fn/helper.js
+++ b/src/js/fn/helper.js
@@ -838,6 +838,50 @@ export function setMyGuildPermissions(permissions) {
   MyGuildPermissions = permissions;
 }
 
+export function fGenericRewardUnits(ability) {
+  let units = 0;
+  if (!ability) return 0;
+
+  const chests = ability.chests || ability.rewardChests || ability.rewards;
+  if (!chests || !Array.isArray(chests)) return 0;
+
+  let totalWeight = 0;
+  chests.forEach((chest) => {
+    const weight =
+      chest.weight ??
+      chest.chance ??
+      chest.probability ??
+      chest.dropChance ??
+      0;
+    totalWeight += weight;
+  });
+  if (!totalWeight) totalWeight = 1;
+
+  chests.forEach((chest) => {
+    const weight =
+      chest.weight ??
+      chest.chance ??
+      chest.probability ??
+      chest.dropChance ??
+      0;
+    const rewards =
+      chest.rewards || (chest.reward && chest.reward.rewards) || [];
+    if (!Array.isArray(rewards)) return;
+    rewards.forEach((reward) => {
+      if (
+        reward.type === 'unit' ||
+        reward.subType === 'unit' ||
+        reward.asset_name === 'penal_unit'
+      ) {
+        const amount = reward.amount ?? reward.count ?? reward.value ?? 0;
+        units += (amount * weight) / totalWeight;
+      }
+    });
+  });
+
+  return units;
+}
+
 // export function getKey(text){
 // 	var key = crypto.createCipher('aes-128-cbc', salt);
 // 	var str = key.update(text, 'utf8', 'hex')

--- a/src/js/msg/StartupService.js
+++ b/src/js/msg/StartupService.js
@@ -199,6 +199,18 @@ export function startupService(msg) {
             entity &&
             entity.abilities &&
             entity.abilities.find(
+              (id) => id.__class__ == 'RandomChestRewardAbility',
+            )
+          ) {
+            const ability = entity.abilities.find(
+              (id) => id.__class__ == 'RandomChestRewardAbility',
+            );
+            City.TrazUnits += helper.fGenericRewardUnits(ability);
+          }
+          if (
+            entity &&
+            entity.abilities &&
+            entity.abilities.find(
               (id) => id.__class__ == 'AddResourcesToGuildTreasuryAbility',
             )
           ) {


### PR DESCRIPTION
## Summary
- add `fGenericRewardUnits` helper to compute expected units from random chests
- tally units for `RandomChestRewardAbility` in StartupService

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6843d5414a4083219bdc23db2f5247e1